### PR TITLE
Updated repo location

### DIFF
--- a/docs/contributor.md
+++ b/docs/contributor.md
@@ -4,11 +4,11 @@
 
 OKD is built from many different open source projects - Fedora CoreOS, the CentOS and UBI RPM ecosystems, cri-o, Kubernetes, and many different extensions to Kubernetes. The `openshift` organization on GitHub holds active development of components on top of Kubernetes and references projects built elsewhere. Generally, you'll want to find the component that interests you and review their README.md for the processes for contributing.
 
-Community process and questions can be raised in our [community repo](https://github.com/openshift/community) and issues [opened in this repository](https://github.com/openshift/okd/issues) (Bugzilla locations coming soon).
+Community process and questions can be raised in our [community repo](https://github.com/openshift/community) and issues [opened in this repository](https://github.com/okd-project/okd/issues) (Bugzilla locations coming soon).
 
-Our unified continuous integration system tests pull requests to the ecosystem and core images, then builds and promotes them after merge. To see the latest development releases of OKD visit [our continuous release page](https://amd64.origin.releases.ci.openshift.org/). These releases are built continuously and expire after a few days. Long lived versions are pinned and then listed on our [stable release page](https://github.com/openshift/okd/releases).
+Our unified continuous integration system tests pull requests to the ecosystem and core images, then builds and promotes them after merge. To see the latest development releases of OKD visit [our continuous release page](https://amd64.origin.releases.ci.openshift.org/). These releases are built continuously and expire after a few days. Long lived versions are pinned and then listed on our [stable release page](https://github.com/okd-project/okd/releases).
 
-All contributions are welcome - OKD uses the Apache 2 license and does not require any contributor agreement to submit patches.  Please open issues for any bugs or problems you encounter, ask questions in the [OKD discussion forum](https://github.com/openshift/okd/discussions){: target=_blank}, or get involved in the [Kubernetes project](https://github.com/kubernetes/kubernetes) at the container runtime layer.
+All contributions are welcome - OKD uses the Apache 2 license and does not require any contributor agreement to submit patches.  Please open issues for any bugs or problems you encounter, ask questions in the [OKD discussion forum](https://github.com/okd-project/okd/discussions){: target=_blank}, or get involved in the [Kubernetes project](https://github.com/kubernetes/kubernetes) at the container runtime layer.
 
 ## Becoming a contributor
 
@@ -26,4 +26,4 @@ The OKD project has a [charter](https://github.com/openshift/community/blob/mast
 The project is managed by a bi-weekly working group video call:
 
 The [main working group](working-groups.md) is where are the major project decisions are made, but when a specific work item needs to be completed a sub-group may be formed, so a focussed set of volunteers can work on a specific area.
- 
+

--- a/docs/crc.md
+++ b/docs/crc.md
@@ -20,7 +20,7 @@ $ crc config view
 - preset                                : okd
 ```
 
-If you encounter any problems, please open a discussion item in the [OKD GitHub Community](https://github.com/openshift/okd/discussions){: target=_blank}!
+If you encounter any problems, please open a discussion item in the [OKD GitHub Community](https://github.com/okd-project/okd/discussions){: target=_blank}!
 
 ## CRC Working group
 

--- a/docs/guides/virt-baremetal-upi/index.md
+++ b/docs/guides/virt-baremetal-upi/index.md
@@ -94,7 +94,7 @@ echo '(allow rpcbind_t unreserved_port_t (udp_socket (name_bind)))' >local_rpcbi
 semodule -i local_rpcbind.cil
 ```
 
-* master nodes are failing the first boot with access denied to `[::1]:53` <https://github.com/openshift/okd/issues/897>
+* master nodes are failing the first boot with access denied to `[::1]:53` <https://github.com/okd-project/okd/issues/897>
 
 While the master node is booting edit the grub config adding to kernel command line `console=null`.
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -4,7 +4,7 @@ There is no official product support for OKD as it is a community project. All a
 
 ## How to ask for help
 
-For questions or feedback, start a discussion on the [discussion forum](https://github.com/openshift/okd/discussions){: target=_blank} or reach us on [Kubernetes Slack on #openshift-users](https://kubernetes.slack.com/)
+For questions or feedback, start a discussion on the [discussion forum](https://github.com/okd-project/okd/discussions){: target=_blank} or reach us on [Kubernetes Slack on #openshift-users](https://kubernetes.slack.com/)
 
 ## Community Etiquette
 
@@ -26,4 +26,4 @@ Please do not tag people you see answering other questions to try to get a faste
 
 ## Raising bugs
 
-We are trying to do all the diagnostic work in the discussion forum rather than using issues for the OKD project.  If you are certain you have discovered a bug, then please raise an [issue](https://github.com/openshift/okd/issues){: target=_blank}, but if you are not sure if you have found a bug then use the discussion forum to discuss it.  If it turns out to be a bug, then the discussion topic can be converted to an issue.
+We are trying to do all the diagnostic work in the discussion forum rather than using issues for the OKD project.  If you are certain you have discovered a bug, then please raise an [issue](https://github.com/okd-project/okd/issues){: target=_blank}, but if you are not sure if you have found a bug then use the discussion forum to discuss it.  If it turns out to be a bug, then the discussion topic can be converted to an issue.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,10 +44,10 @@ We know you've got great ideas for improving OKD and its network of open source 
 
 All contributions are welcome! OKD uses the Apache 2 license and does not require any contributor agreement to submit patches. Please open issues for any bugs or problems you encounter, ask questions in the **#openshift-users** on Kubernetes Slack Channel, or get involved in the OKD-WG by joining the OKD-WG google group.
 
-- Get started with the [Contributors Guide](https://github.com/openshift/okd/blob/master/CONTRIBUTING.md)
+- Get started with the [Contributors Guide](https://github.com/okd-project/okd/blob/master/CONTRIBUTING.md)
 - Read [the documentation](https://docs.okd.io/latest/welcome/index.html)
 - Read [our charter](https://github.com/openshift/community/blob/master/CHARTER.md)
-- Help Resolve an [Open Issue](https://github.com/openshift/okd/issues)
+- Help Resolve an [Open Issue](https://github.com/okd-project/okd/issues)
 
 ### Connect to the community
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ You can find examples of OKD installations, setup by OKD community members in th
 
 ## Getting Started
 
-To obtain the openshift installer and client, visit [releases](https://github.com/openshift/okd/releases){: target=_blank} for stable versions or [https://amd64.origin.releases.ci.openshift.org/](https://amd64.origin.releases.ci.openshift.org/){: target=_blank} for nightlies.
+To obtain the openshift installer and client, visit [releases](https://github.com/okd-project/okd/releases){: target=_blank} for stable versions or [https://amd64.origin.releases.ci.openshift.org/](https://amd64.origin.releases.ci.openshift.org/){: target=_blank} for nightlies.
 
 You can verify the downloads using:
 
@@ -76,16 +76,16 @@ oc adm release extract --tools quay.io/openshift/okd:4.5.0-0.okd-2020-07-14-1537
 
 There are full instructions in the [OKD documentation](https://docs.okd.io/latest/installing/installing-preparing.html){: target=_blank} for each supported platform, but the main steps for an IPI install are:
 
-1. extract the downloaded tarballs and copy the binaries into your PATH. 
+1. extract the downloaded tarballs and copy the binaries into your PATH.
 2. run the following from an empty directory:
     ```shell
     openshift-install create cluster
     ```
 3. follow the prompts to create the install config
     - you will need to have cloud credentials set in your shell properly before installation.
-    - you must have permission to configure the appropriate cloud resources from that account (such as VPCs, instances, and DNS records). 
+    - you must have permission to configure the appropriate cloud resources from that account (such as VPCs, instances, and DNS records).
     - you must have already configured a public DNS zone on your chosen cloud before the install starts.
-    - you will also be prompted for a pull-secret that will be made available to all of of your machines - for OKD4 you should either paste the pull-secret you use for your registry, or paste `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` to bypass the required value check (see [bug #182](https://github.com/openshift/okd/issues/182){: target=_blank}).
+    - you will also be prompted for a pull-secret that will be made available to all of of your machines - for OKD4 you should either paste the pull-secret you use for your registry, or paste `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` to bypass the required value check (see [bug #182](https://github.com/okd-project/okd/issues/182){: target=_blank}).
 
 Once the install completes successfully the console URL and an admin username and password will be printed. If your DNS records were correct, you should be able to log in to your new OKD4 cluster!
 

--- a/docs/okd_tech_docs/index.md
+++ b/docs/okd_tech_docs/index.md
@@ -20,13 +20,13 @@ In addition to the above this section will also look at the Red Hat build and te
 
 ## OKD Releases
 
-OKD is a Kubernetes based platform that delivers a fully managed platform from the core operating system to the Kubernetes platform and the services running on it.  All aspects of OKD are managed by a collection of operators.  
+OKD is a Kubernetes based platform that delivers a fully managed platform from the core operating system to the Kubernetes platform and the services running on it.  All aspects of OKD are managed by a collection of operators.
 
 OKD shares most of the same source code as Red Hat OpenShift.  One of the primary differences is that OKD uses [Fedora CoreOS](https://getfedora.org/en/coreos?stream=stable){target=_blank} where OpenShift uses Red Hat Enterprise Linux CoreOS as the base platform for cluster nodes.
 
 An OKD release is a strictly defined set of software.  A release is defined by a **release payload**, which contains an operator (Cluster Version Operator), a list of manifests to apply and a reference file.  You can get information about a release using the **oc** command line utility, `oc adm release info <release name>`.
 
-You can find the latest available release [here](https://github.com/openshift/okd/releases){target=_blank}.
+You can find the latest available release [here](https://github.com/okd-project/okd/releases){target=_blank}.
 
 You can get the current version of your cluster using the `oc get clusterversion` command, or from the Cluster Settings page in the Administration section of the OKD web console.
 

--- a/docs/okd_tech_docs/troubleshoot.md
+++ b/docs/okd_tech_docs/troubleshoot.md
@@ -2,6 +2,6 @@
 
 !!!Warning
     This section is under construction
-    
+
 !!!Todo
-    Complete this section from comments in [discussion thread](https://github.com/openshift/okd/discussions/1198){target=_blank}
+    Complete this section from comments in [discussion thread](https://github.com/okd-project/okd/discussions/1198){target=_blank}

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -20,7 +20,7 @@
                         </a>
                     </li>
                     <li class="github">
-                        <a href="https://github.com/openshift/okd">
+                        <a href="https://github.com/okd-project/okd">
                             <span>
                                 <i class="fa fa-github"></i>
                             </span>


### PR DESCRIPTION
As found in https://github.com/okd-project/planning/issues/18, lets update the repo location on these pages to the new okd-project org.