### PR TITLE
Update 2022-10-25-OKD-Streams-Building-the-Next-Generation-of-OKD-tog…

### DIFF
--- a/docs/blog/2022-10-25-OKD-Streams-Building-the-Next-Generation-of-OKD-together.md
+++ b/docs/blog/2022-10-25-OKD-Streams-Building-the-Next-Generation-of-OKD-together.md
@@ -6,7 +6,7 @@
 
 date: 2022-10-25
 
-OKD is the community distribution of Kubernetes that powers Red Hat OpenShift. The OKD community has created reusable Tekton build pipelines on a shared Kubernetes cluster for the OKD build pipelines so that they could manage the build & release processes for OKD in the open. With the operate-first.cloud hosted on AWS, the OKD community has launched a fully open source release pipeline that the community can participate in to help support and manage the release cycle ourselves. The OKD Community is now able to build and release stable builds of OKD 4.12 on both Fedora CoreOS and the newly introduced CentOS Stream CoreOS. We are calling it OKD Streams.
+OKD is the community distribution of Kubernetes that powers Red Hat OpenShift. The OKD community has created reusable Tekton build pipelines on a shared Kubernetes cluster for the OKD build pipelines so that they could manage the build & release processes for OKD in the open. With the [operate-first.cloud](https://www.operate-first.cloud/){target=_blank} hosted at the [massopen.cloud](https://massopen.cloud/){target=_blank}, the OKD community has launched a fully open source release pipeline that the community can participate in to help support and manage the release cycle ourselves. The OKD Community is now able to build and release stable builds of OKD 4.12 on both Fedora CoreOS and the newly introduced CentOS Stream CoreOS. We are calling it OKD Streams.
 
 ## New Patterns, New CI/CD Pipelines and a new CoreOS
 


### PR DESCRIPTION
…ether.md

Dear team, a little errata:
the part of operate-first okd used & uses was/is NOT hosted on AWS, but open massopen.cloud, `The MOC Alliance aims to accelerate the pace of discovery and innovation in an open production research-focused cloud.` Happy Friday :-)