### PR TITLE
add an okd communications page

### DIFF
--- a/docs/communications.md
+++ b/docs/communications.md
@@ -1,0 +1,73 @@
+# OKD Working Group Communications
+
+The working group issues regular communications through several different methods.
+There are also a few ways to contact the working group depending on the type of
+communication needed. This page will help you navigate the various communication
+channels that the working group utilizes.
+
+## E-Mail
+
+The working group maintains a mailing list as well as several email addresses.
+
+**Mailing List**
+
+[okd-wg mailing list](https://groups.google.com/g/okd-wg)
+
+The purpose of this list is to discuss, give guidance & enable collaboration on
+current development efforts for OKD4, Fedora CoreOS (FCOS) & Kubernetes. Please
+note that the focus of this list is the active development of OKD, and the
+processes of this community, its is not intended as a forum for reporting bugs or
+requesting help with operating OKD.
+
+**Reporting Addresses**
+
+The working group uses several e-mail addresses to receive communications from the
+community based on the intent of the message.
+
+[chairs@okd.io](mailto:chairs@okd.io)
+
+The chairs address is for messages that are related to the working group and its
+processes. It is intended for communications that will go directly to the working
+group chairs and not the wider community.
+
+[security@okd.io](mailto:security@okd.io)
+
+The security address is intended for any reporting of sensitive or confidential
+security related bugs and findings about OKD.
+
+[info@okd.io](mailto:info@okd.io)
+
+The info address is for requesting general information about the working group
+and its processes.
+
+## Social Media
+
+The working group uses social media to broadcast updates about new releases, working
+group meetings, and community events.
+
+**Twitter**
+
+[@okd_io](https://twitter.com/okd_io)
+
+## Slack
+
+The working group maintains a presence on the
+[Kubernetes community Slack instance](https://kubernetes.slack.com) in the
+`#openshift-users` channel. This channel is a good place to come for OKD-specific
+help with operations and usage.
+
+## GitHub
+
+The working group maintains several repositories on [GitHub](https://github.com/okd-project)
+in the OKD-Project organization. These repositories contain information and discussions
+about OKD and the working group's future plans.
+
+[okd-project/okd discussions](https://github.com/okd-project/okd/discussions)
+
+The okd repository discussions board is a good place to visit for researching or raising
+specific operational issues with OKD.
+
+[okd-project/planning project board](https://github.com/orgs/okd-project/projects/1)
+
+The planning repository contains a kanban board which records the current state of the working
+group and its related projects.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ Join the [OKD Working Group](contributor.md)
 - Follow the [public mailing lists](https://groups.google.com/g/okd-wg)
 - Chat with us on [Matrix](https://matrix.to/#/#okd:fedoraproject.org)
 - Chat with us on the [#openshift-users channel on Slack](https://kubernetes.slack.com/messages/openshift-users/)
+- See more options on the [OKD Working Group Communications page](communications.md)
 
 ## Standardization through Containerization
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
   - OKD Working Group:
       - About: working-groups.md
       - Charter: charter.md
+      - Communications: communications.md
       - Minutes: working-group/minutes/minutes.md
       - Subgroups:
           - Documentation:


### PR DESCRIPTION
this change introduces a communications page to the okd working group section of the site. the page covers the most common ways to communicate with the working group.

fiixes #19 