### PR TITLE
update main workflow fedora image to 36

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/fedora/fedora:35
+      image: quay.io/fedora/fedora:36
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
the 35 version of this image doesn't appear to be on quay anymore, this change updates to a new version.