### PR TITLE
Update main workflow image to latest fedora after F36's mirror removal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,22 +12,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/fedora/fedora:36
+      image: quay.io/fedora/fedora:latest
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Switch to a recent nodejs version as default is nodejs 10 and install NPM.
       - name: Install NPM
         run: |
-          dnf -y module switch-to nodejs:14
           dnf install -y nodejs npm
 
       - name: Install PIP
         run: |
           dnf install -y python3-pip
-          
+
       - name: Install Git
         run: |
           dnf install -y git
@@ -36,9 +34,8 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           npm ci
-          
+
       - name: Run the build
         run: |
           export PATH=$PATH:node_modules/.bin/
           ./build.sh
-          


### PR DESCRIPTION
CI fails at `Install NPM` step with:

```
  dnf -y module switch-to nodejs:14
  dnf install -y nodejs npm
  shell: sh -e {0}
Fedora 36 - x86_64                              314  B/s | 359  B     00:01    
Errors during downloading metadata for repository 'fedora':
  - Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=fedora-36&arch=x86_64 (IP: 152.19.134.198)
  - Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=fedora-36&arch=x86_64 (IP: 140.211.169.196)
  - Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=fedora-36&arch=x86_64 (IP: 38.145.60.21)
Error: Failed to download metadata for repo 'fedora': Cannot prepare internal mirrorlist: Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=fedora-36&arch=x86_64 (IP: 38.145.60.21)
```

How about always using the latest stable release of Fedora? I would assume it requires less changes / fixes to CI than bumping Fedora's version number every now and then 😆