### PR TITLE
Remove Google+ from the footer

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1424,10 +1424,6 @@ ul.social li.twitter:hover span i {
     color: #3C8FC9 !important
 }
 
-ul.social li.google:hover span i {
-    color: #d73d32 !important
-}
-
 ul.social li.github:hover span i {
     color: #000 !important
 }

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -26,13 +26,6 @@
                             </span>
                         </a>
                     </li>
-                    <li class="google">
-                        <a href="https://plus.google.com/communities/114361859072744017486">
-                            <span>
-                                <i class="fa fa-google-plus-square"></i>
-                            </span>
-                        </a>
-                    </li>
                     <li class="facebook">
                         <a href="https://www.facebook.com/openshift">
                             <span>


### PR DESCRIPTION
Google Plus was shut down in 2019, so this link is no longer needed