### PR TITLE
Update mkdocs deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Do not use with Docker builds, only for local dev with mkdocs CLI
-mkdocs==1.5.3
-mkdocs-material==9.4.6
-mkdocs-minify-plugin==0.7.1
+mkdocs==1.6.0
+mkdocs-material==9.5.25
+mkdocs-minify-plugin==0.8.0
 git+https://github.com/linkchecker/linkchecker@v10.3.0#egg=linkchecker


### PR DESCRIPTION
This fixes the build issue in https://github.com/okd-project/okd.io/actions/runs/9290433582/job/25566646053 

Updating `mkdocs` packages fixes the issue with Google fonts not loading correctly. I also took the liberty of updating `mkdocs-material` and `mkdocs-minify`. 

After running the `docker-build-image`, `docker-build`, then `docker-server`, everything appears to be in working order and the site can build and serve normally again 